### PR TITLE
Update Android HLSDK to 2.4.0

### DIFF
--- a/SampleAndroid/app/build.gradle
+++ b/SampleAndroid/app/build.gradle
@@ -23,7 +23,7 @@ android {
 
     defaultConfig {
         applicationId "com.vipaar.lime.samplehl"
-        minSdkVersion 21
+        minSdkVersion 23
         targetSdkVersion project.TARGET_ANDROID_SDK_VERSION.toInteger()
         versionCode 1
         versionName "1.0"
@@ -50,7 +50,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.vipaar.lime:hlsdk-light:2.0.1'
+    implementation 'com.vipaar.lime:hlsdk-light:2.4.0'
 
     implementation 'com.jakewharton.timber:timber:5.0.1'
     implementation 'com.google.android.material:material:1.9.0'

--- a/SampleAndroid/app/src/main/AndroidManifest.xml
+++ b/SampleAndroid/app/src/main/AndroidManifest.xml
@@ -33,7 +33,8 @@
 
         <service
             android:name=".SampleInCallService"
-            android:exported="false" />
+            android:exported="false"
+            android:foregroundServiceType="mediaProjection" />
     </application>
 
 </manifest>


### PR DESCRIPTION
This update requires a min sdk target of 23.
In order to support the new screen sharing feature, The InCallService needs to declare foregroundServiceType as mediaProjection.